### PR TITLE
Resolving #113, re-releasing v1.2.0

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -27,6 +27,7 @@
 
 ---
 ## 1.2.0 (2023-11-19)
+
 * [Issue #126](https://github.com/jlyons210/discord-bot-ol-bootsie/issues/126) - Resolved
   * Removed retry logic from OpenAI function calls, as the library handles these natively now. Now it will bubble up the original error.
   * Removed `src/lib/OpenAI/Errors/*`
@@ -35,6 +36,7 @@
       * `OpenAIRetriesExceededError`
       * `OpenAIUnexpectedError`
   * Removed `axios` dependency. It was only in place to parse the errors returned by `openai-node` 3.x to support retry logic.
+* [Issue #113](https://github.com/jlyons210/discord-bot-ol-bootsie/issues/113) - Resolved
 * Minor fix: `CreateImage` token logging used display name, switched to username to align with token spending/refunding.
 * Updated `devDependencies`
 

--- a/src/lib/DiscordBot/DiscordBot.ts
+++ b/src/lib/DiscordBot/DiscordBot.ts
@@ -437,11 +437,18 @@ export class DiscordBot {
 
       void this._logger.logDebug(`${discordBotMessage.DiscordMessage.id}: sending chat completion response to channel`);
       discordResponse.forEach(async responseText => {
-        if (discordBotMessage.MessageType === DiscordBotMessageType.DirectMessage) {
-          await discordBotMessage.DiscordMessage.channel.send(responseText);
+        try {
+          if (discordBotMessage.MessageType === DiscordBotMessageType.DirectMessage) {
+            await discordBotMessage.DiscordMessage.channel.send(responseText);
+          }
+          else {
+            await discordBotMessage.DiscordMessage.reply(responseText);
+          }
         }
-        else {
-          await discordBotMessage.DiscordMessage.reply(responseText);
+        catch (e) {
+          if (e instanceof Error) {
+            void this._logger.logError(`${discordBotMessage.DiscordMessage.id}: ${e.message}`);
+          }
         }
       });
     }


### PR DESCRIPTION
## 1.2.0 (2023-11-19)

* [Issue #126](https://github.com/jlyons210/discord-bot-ol-bootsie/issues/126) - Resolved
  * Removed retry logic from OpenAI function calls, as the library handles these natively now. Now it will bubble up the original error.
  * Removed `src/lib/OpenAI/Errors/*`
    * `OpenAIError`
      * `OpenAIBadRequestError`
      * `OpenAIRetriesExceededError`
      * `OpenAIUnexpectedError`
  * Removed `axios` dependency. It was only in place to parse the errors returned by `openai-node` 3.x to support retry logic.
* [Issue #113](https://github.com/jlyons210/discord-bot-ol-bootsie/issues/113) - Resolved
* Minor fix: `CreateImage` token logging used display name, switched to username to align with token spending/refunding.
* Updated `devDependencies`