### PR TITLE
Resolving #134, again

### DIFF
--- a/src/lib/DiscordBot/DiscordBot.ts
+++ b/src/lib/DiscordBot/DiscordBot.ts
@@ -313,12 +313,6 @@ export class DiscordBot {
       `${message.id}: message recieved, entering handleMessageCreate(message)`,
     );
 
-    // 1000000000000000000: Message URL: https://discord.com/channels/[guildId]/[channelId]/[messageId]
-    void this.logger.logDebug(
-      `${message.id}: Message URL: `
-      + `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`,
-    );
-
     this.historyMessageBucket.add(new HistoryMessage({
       conversationKey: discordBotMessage.ConversationKey,
       payload:
@@ -329,8 +323,16 @@ export class DiscordBot {
         }),
     }));
 
-    // 1000000000000000000: message type is DirectMessage
+    // 1000000000000000000: message type is [MessageType]
     void this.logger.logDebug(`${message.id}: message type is ${discordBotMessage.MessageType}`);
+
+    if (message.guildId !== null) {
+      // 1000000000000000000: Message URL: https://discord.com/channels/[guildId]/[channelId]/[messageId]
+      void this.logger.logDebug(
+        `${message.id}: Message URL: `
+        + `https://discord.com/channels/${message.guildId}/${message.channelId}/${message.id}`,
+      );
+    }
 
     const intent = await this.getMessageIntent(discordBotMessage);
     switch (discordBotMessage.MessageType) {


### PR DESCRIPTION
Made a small adjustment to only print the URL if `message.guildId` is populated (null when the message is a DM).